### PR TITLE
feat: scaffold pwa teaching console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.vite/
+.DS_Store
+npm-debug.log*
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>智慧跳绳教学管理平台</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "jumprope-pwa",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "dexie": "^4.0.8",
+    "lucide-react": "^0.424.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
+    "recharts": "^2.12.7",
+    "zustand": "^4.5.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.7",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.3",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.8"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,56 @@
+import { Route, Routes } from 'react-router-dom';
+import { lazy, Suspense } from 'react';
+import { LayoutShell } from './components/LayoutShell';
+
+const ClassesIndex = lazy(() => import('./pages/classes/index'));
+const ClassNew = lazy(() => import('./pages/classes/new'));
+const ClassDetail = lazy(() => import('./pages/classes/[id]'));
+const SessionPanel = lazy(() => import('./pages/session/[id]'));
+const StudentsIndex = lazy(() => import('./pages/students/index'));
+const StudentsNew = lazy(() => import('./pages/students/new'));
+const StudentProfile = lazy(() => import('./pages/students/[id]'));
+const TemplatesIndex = lazy(() => import('./pages/templates/index'));
+const TemplateNew = lazy(() => import('./pages/templates/new'));
+const AssessmentsIndex = lazy(() => import('./pages/assessments/index'));
+const FinanceIndex = lazy(() => import('./pages/finance/index'));
+const ReportPreview = lazy(() => import('./pages/reports/[studentId]'));
+const SettingsIndex = lazy(() => import('./pages/settings/index'));
+const Wallboard = lazy(() => import('./pages/wallboard'));
+
+function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<LayoutShell />}>
+        <Route index element={<ClassesIndex />} />
+        <Route path="classes">
+          <Route index element={<ClassesIndex />} />
+          <Route path="new" element={<ClassNew />} />
+          <Route path=":id" element={<ClassDetail />} />
+        </Route>
+        <Route path="session/:id" element={<SessionPanel />} />
+        <Route path="students">
+          <Route index element={<StudentsIndex />} />
+          <Route path="new" element={<StudentsNew />} />
+          <Route path=":id" element={<StudentProfile />} />
+        </Route>
+        <Route path="templates">
+          <Route index element={<TemplatesIndex />} />
+          <Route path="new" element={<TemplateNew />} />
+        </Route>
+        <Route path="assessments" element={<AssessmentsIndex />} />
+        <Route path="finance" element={<FinanceIndex />} />
+        <Route path="reports/:studentId" element={<ReportPreview />} />
+        <Route path="settings" element={<SettingsIndex />} />
+        <Route path="wallboard" element={<Wallboard />} />
+      </Route>
+    </Routes>
+  );
+}
+
+export default function App() {
+  return (
+    <Suspense fallback={<div className="p-6 text-lg font-semibold">加载中...</div>}>
+      <AppRoutes />
+    </Suspense>
+  );
+}

--- a/src/components/AttendanceGrid.tsx
+++ b/src/components/AttendanceGrid.tsx
@@ -1,0 +1,38 @@
+import type { AttendanceItem, Student } from '../types/models';
+
+interface Props {
+  students: Student[];
+  value: AttendanceItem[];
+  onChange: (value: AttendanceItem[]) => void;
+}
+
+export function AttendanceGrid({ students, value, onChange }: Props) {
+  const toggle = (studentId: string) => {
+    const next = value.some((v) => v.studentId === studentId)
+      ? value.filter((v) => v.studentId !== studentId)
+      : [...value, { studentId, present: true }];
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-slate-600">出勤表</h3>
+      <div className="grid grid-cols-2 gap-2">
+        {students.map((s) => {
+          const item = value.find((v) => v.studentId === s.id);
+          const present = item?.present ?? false;
+          return (
+            <button
+              key={s.id}
+              onClick={() => toggle(s.id)}
+              className={`rounded-xl border px-3 py-2 text-left text-sm shadow-sm transition ${present ? 'border-brand-primary bg-white text-brand-primary' : 'border-slate-200 bg-slate-50 text-slate-500 hover:border-brand-primary/40'}`}
+            >
+              <div className="font-medium">{s.name}</div>
+              <div className="text-xs">{present ? '已出勤' : '未出勤'}</div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommentEditor.tsx
+++ b/src/components/CommentEditor.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+interface Props {
+  onSubmit: (comment: string, tags: string[]) => void;
+}
+
+const defaultTags = ['专注', '积极', '配合', '节奏', '技术'];
+
+export function CommentEditor({ onSubmit }: Props) {
+  const [comment, setComment] = useState('');
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = (tag: string) => {
+    setSelected((prev) => (prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]));
+  };
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4">
+      <h3 className="text-sm font-semibold text-slate-600">课堂点评</h3>
+      <div className="flex flex-wrap gap-2 text-xs">
+        {defaultTags.map((tag) => (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => toggle(tag)}
+            className={`rounded-full border px-3 py-1 ${selected.includes(tag) ? 'border-brand-primary bg-brand-primary/10 text-brand-primary' : 'border-slate-200 text-slate-500 hover:border-brand-primary/40'}`}
+          >
+            #{tag}
+          </button>
+        ))}
+      </div>
+      <textarea
+        value={comment}
+        onChange={(event) => setComment(event.target.value)}
+        className="h-24 w-full rounded-xl border border-slate-200 p-3 text-sm"
+        placeholder="记录本节课表现亮点/建议"
+      />
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => onSubmit(comment, selected)}
+          className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white"
+        >
+          保存点评
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EnergyBar.tsx
+++ b/src/components/EnergyBar.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  value: number;
+  max?: number;
+}
+
+export function EnergyBar({ value, max = 100 }: Props) {
+  const pct = Math.max(0, Math.min(100, Math.round((value / max) * 100)));
+  return (
+    <div className="h-3 w-full rounded-full bg-slate-200/50">
+      <div
+        className="h-3 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 transition-[width] duration-700"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/src/components/ExportPdfButton.tsx
+++ b/src/components/ExportPdfButton.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  target: string;
+  fileName: (options?: { name: string }) => string;
+  student?: { name: string };
+}
+
+export function ExportPdfButton({ target, fileName, student }: Props) {
+  const handleExport = async () => {
+    console.info('Exporting PDF for target', target);
+    alert(`模拟导出：${fileName({ name: student?.name ?? 'student' })}`);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleExport}
+      className="rounded-full border border-brand-primary px-4 py-2 text-sm font-semibold text-brand-primary hover:bg-brand-primary/10"
+    >
+      导出成长报告
+    </button>
+  );
+}

--- a/src/components/FinanceCards.tsx
+++ b/src/components/FinanceCards.tsx
@@ -1,0 +1,41 @@
+interface FinanceKpis {
+  totalStudents: number;
+  totalRevenue: number;
+  consumed: number;
+  remaining: number;
+  arpu: number;
+  consumeRate: number;
+}
+
+interface Props {
+  kpis: FinanceKpis;
+}
+
+const labels: Record<keyof FinanceKpis, string> = {
+  totalStudents: '在读学员',
+  totalRevenue: '总收入 (元)',
+  consumed: '已消课时',
+  remaining: '剩余课时',
+  arpu: '人均收入 (元)',
+  consumeRate: '课消率 (%)'
+};
+
+export function FinanceCards({ kpis }: Props) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {(Object.keys(labels) as (keyof FinanceKpis)[]).map((key) => (
+        <div
+          key={key}
+          className="rounded-3xl border border-white/10 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 p-[1px] shadow-[0_0_40px_rgba(74,108,247,0.25)]"
+        >
+          <div className="h-full rounded-3xl bg-slate-950/90 p-5 text-white">
+            <div className="text-xs uppercase tracking-widest text-white/70">{labels[key]}</div>
+            <div className="mt-3 text-3xl font-black tabular-nums">
+              {key === 'consumeRate' ? `${(kpis[key] ?? 0).toFixed(1)}%` : Math.round(kpis[key] ?? 0)}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/FreestylePass.tsx
+++ b/src/components/FreestylePass.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import type { FreestyleChallengeRecord, RankMove, Student } from '../types/models';
+import { nanoid } from '../utils/id';
+
+interface Props {
+  students: Student[];
+  moves: RankMove[];
+  onChange: (records: FreestyleChallengeRecord[]) => void;
+}
+
+export function FreestylePass({ students, moves, onChange }: Props) {
+  const options = useMemo(() => [...moves].sort((a, b) => a.rank - b.rank), [moves]);
+
+  const handleSelect = (studentId: string, moveId: string) => {
+    const move = options.find((m) => m.id === moveId);
+    if (!move) return;
+    const record: FreestyleChallengeRecord = {
+      id: nanoid(),
+      studentId,
+      moveId: move.id,
+      passed: true,
+      date: new Date().toISOString()
+    };
+    onChange([record]);
+  };
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <h3 className="text-base font-semibold">花样挑战</h3>
+      <div className="space-y-2">
+        {students.map((student) => (
+          <div key={student.id} className="space-y-1">
+            <div className="text-sm font-medium">{student.name}</div>
+            <select
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+              onChange={(event) => handleSelect(student.id, event.target.value)}
+            >
+              <option value="">选择花样动作</option>
+              {options.map((move) => (
+                <option key={move.id} value={move.id}>
+                  {`L${move.rank} · ${move.name}`}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HighlightsCard.tsx
+++ b/src/components/HighlightsCard.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  highlights: string[];
+}
+
+export function HighlightsCard({ highlights }: Props) {
+  if (!highlights.length) {
+    return (
+      <div className="rounded-2xl border border-dashed border-brand-primary/40 bg-white p-4 text-sm text-slate-500">
+        本节课尚未生成高光，完成速度/花样录入后自动生成。
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-2xl border border-brand-primary/30 bg-white p-4 shadow-[0_0_30px_rgba(74,108,247,0.15)]">
+      <h3 className="text-sm font-semibold text-brand-primary">本节高光</h3>
+      <ul className="mt-2 space-y-2 text-sm">
+        {highlights.map((item) => (
+          <li key={item} className="flex items-start gap-2">
+            <span className="mt-1 h-2 w-2 rounded-full bg-brand-primary" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/HighlightsMarquee.tsx
+++ b/src/components/HighlightsMarquee.tsx
@@ -1,0 +1,23 @@
+interface Props {
+  highlights: string[];
+}
+
+export function HighlightsMarquee({ highlights }: Props) {
+  if (!highlights.length) {
+    return <div className="text-white/60">等待高光产生...</div>;
+  }
+  return (
+    <div className="flex gap-6 overflow-hidden text-2xl font-semibold text-white">
+      <div className="animate-[scroll_20s_linear_infinite] flex gap-6">
+        {highlights.map((item, idx) => (
+          <span key={`${item}-${idx}`} className="whitespace-nowrap">
+            ✨ {item}
+          </span>
+        ))}
+      </div>
+      <style>{
+        '@keyframes scroll {0% {transform: translateX(0);} 100% {transform: translateX(-50%);}}'
+      }</style>
+    </div>
+  );
+}

--- a/src/components/LayoutShell.tsx
+++ b/src/components/LayoutShell.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import { NavigationMenu } from './NavigationMenu';
+
+export function LayoutShell() {
+  return (
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-bold tracking-wide text-brand-primary">勇士跳绳 · 教学中台</h1>
+            <p className="text-xs text-slate-500">PWA 离线 · Dexie 本地化 · 游戏化成长档案</p>
+          </div>
+          <NavigationMenu />
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-6">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,28 @@
+interface Item {
+  id: string;
+  name: string;
+  points: number;
+}
+
+interface Props {
+  items: Item[];
+}
+
+export function Leaderboard({ items }: Props) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-white backdrop-blur">
+      <h3 className="text-2xl font-black tracking-wide">积分榜</h3>
+      <ol className="mt-4 space-y-3">
+        {items.map((item, idx) => (
+          <li key={item.id} className="flex items-center justify-between text-lg">
+            <span className="flex items-center gap-3 font-semibold">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-sm">#{idx + 1}</span>
+              {item.name}
+            </span>
+            <span className="tabular-nums text-2xl font-black text-brand-secondary">{item.points}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -1,0 +1,30 @@
+import { NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/classes', label: '班级' },
+  { to: '/students', label: '学员' },
+  { to: '/templates', label: '模板库' },
+  { to: '/session/demo', label: '上课面板' },
+  { to: '/wallboard', label: '壁板模式' },
+  { to: '/assessments', label: '测评' },
+  { to: '/finance', label: '财务' },
+  { to: '/settings', label: '设置' }
+];
+
+export function NavigationMenu() {
+  return (
+    <nav className="flex flex-wrap gap-3 text-sm">
+      {links.map((link) => (
+        <NavLink
+          key={link.to}
+          to={link.to}
+          className={({ isActive }) =>
+            `rounded-full px-3 py-1 transition-colors ${isActive ? 'bg-brand-primary text-white' : 'text-slate-600 hover:bg-slate-200'}`
+          }
+        >
+          {link.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/src/components/PointsTicker.tsx
+++ b/src/components/PointsTicker.tsx
@@ -1,0 +1,8 @@
+interface Props {
+  delta: number;
+}
+
+export function PointsTicker({ delta }: Props) {
+  const prefix = delta >= 0 ? '+' : '';
+  return <span className="text-lg font-black text-brand-secondary animate-bounce">{`${prefix}${delta}`}</span>;
+}

--- a/src/components/ProgressChart.tsx
+++ b/src/components/ProgressChart.tsx
@@ -1,0 +1,29 @@
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+interface SeriesPoint {
+  date: string;
+  score: number;
+}
+
+interface Props {
+  series: SeriesPoint[];
+  title?: string;
+  unit?: string;
+}
+
+export function ProgressChart({ series, title, unit }: Props) {
+  return (
+    <div className="space-y-2">
+      {title ? <h3 className="text-sm font-semibold text-slate-600">{title}</h3> : null}
+      <ResponsiveContainer width="100%" height={220}>
+        <AreaChart data={series}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+          <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+          <YAxis tick={{ fontSize: 10 }} width={32} unit={unit} />
+          <Tooltip />
+          <Area type="monotone" dataKey="score" stroke="#4A6CF7" fill="#4A6CF7" fillOpacity={0.2} />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -1,0 +1,28 @@
+import { Radar, RadarChart as ReRadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import type { FitnessQuality } from '../types/models';
+
+interface Props {
+  data: Record<FitnessQuality, number>;
+  baselineP50?: Record<FitnessQuality, number>;
+}
+
+export function RadarChart({ data, baselineP50 }: Props) {
+  const chartData = Object.entries(data).map(([key, value]) => ({
+    quality: key,
+    score: value,
+    baseline: baselineP50?.[key as FitnessQuality] ?? 0
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={320}>
+      <ReRadarChart data={chartData} outerRadius="80%">
+        <PolarGrid />
+        <PolarAngleAxis dataKey="quality" tick={{ fontSize: 12 }} />
+        <PolarRadiusAxis domain={[0, 100]} tick={{ fontSize: 10 }} />
+        <Radar name="当前" dataKey="score" stroke="#4A6CF7" fill="#4A6CF7" fillOpacity={0.4} />
+        <Radar name="同龄 P50" dataKey="baseline" stroke="#94A3B8" fill="#94A3B8" fillOpacity={0.2} />
+        <Tooltip />
+      </ReRadarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/RankBadge.tsx
+++ b/src/components/RankBadge.tsx
@@ -1,0 +1,14 @@
+interface Props {
+  rank: number;
+}
+
+export function RankBadge({ rank }: Props) {
+  const colors = ['bg-zinc-400', 'bg-blue-500', 'bg-purple-600', 'bg-amber-500', 'bg-rose-500'];
+  const c = colors[Math.min(colors.length - 1, Math.max(0, Math.floor((rank - 1) / 2)))];
+  return (
+    <div className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-white ${c}`}>
+      <span className="text-xs tracking-wide">段位</span>
+      <b className="text-sm font-semibold">{rank}</b>
+    </div>
+  );
+}

--- a/src/components/SpeedBoard.tsx
+++ b/src/components/SpeedBoard.tsx
@@ -1,0 +1,31 @@
+interface Item {
+  id: string;
+  name: string;
+  reps: number;
+  isPr?: boolean;
+}
+
+interface Props {
+  windowLabel: string;
+  items: Item[];
+}
+
+export function SpeedBoard({ windowLabel, items }: Props) {
+  return (
+    <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-white backdrop-blur">
+      <div className="text-sm uppercase tracking-[0.5em] text-white/60">{windowLabel}</div>
+      <h3 className="mt-2 text-2xl font-black">速度榜</h3>
+      <ul className="mt-4 space-y-3 text-lg">
+        {items.map((item) => (
+          <li key={item.id} className="flex items-center justify-between">
+            <span className="font-semibold">{item.name}</span>
+            <span className="flex items-center gap-2">
+              <span className="tabular-nums text-2xl font-black">{item.reps}</span>
+              {item.isPr ? <span className="rounded-full bg-amber-400 px-3 py-1 text-xs font-bold text-amber-900">PR</span> : null}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/SpeedInput.tsx
+++ b/src/components/SpeedInput.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { nanoid } from '../utils/id';
+import type { Student, WindowSec, JumpMode, SpeedRecord } from '../types/models';
+
+interface Props {
+  students: Student[];
+  defaultWindow?: WindowSec;
+  defaultMode?: JumpMode;
+  onSubmit: (rows: SpeedRecord[]) => void;
+}
+
+const windows: WindowSec[] = [10, 20, 30, 60];
+const modes: JumpMode[] = ['single', 'double'];
+
+export function SpeedInput({ students, defaultWindow = 30, defaultMode = 'single', onSubmit }: Props) {
+  const [window, setWindow] = useState<WindowSec>(defaultWindow);
+  const [mode, setMode] = useState<JumpMode>(defaultMode);
+  const [values, setValues] = useState<Record<string, number>>({});
+
+  const handleSave = () => {
+    const rows: SpeedRecord[] = students
+      .filter((s) => values[s.id] != null)
+      .map((s) => ({
+        id: nanoid(),
+        studentId: s.id,
+        mode,
+        window,
+        reps: Number(values[s.id]),
+        date: new Date().toISOString()
+      }));
+    onSubmit(rows);
+  };
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold">速度录入</h3>
+          <p className="text-xs text-slate-500">支持 10/20/30/60 秒单双摇</p>
+        </div>
+        <div className="flex gap-2 text-xs">
+          <select
+            value={window}
+            onChange={(e) => setWindow(Number(e.target.value) as WindowSec)}
+            className="rounded-full border border-slate-200 px-3 py-1"
+          >
+            {windows.map((w) => (
+              <option key={w} value={w}>{`${w}s`}</option>
+            ))}
+          </select>
+          <select
+            value={mode}
+            onChange={(e) => setMode(e.target.value as JumpMode)}
+            className="rounded-full border border-slate-200 px-3 py-1 capitalize"
+          >
+            {modes.map((m) => (
+              <option key={m} value={m}>
+                {m === 'single' ? '单摇' : '双摇'}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="space-y-2">
+        {students.map((student) => (
+          <label key={student.id} className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 px-3 py-2 text-sm">
+            <span className="font-medium">{student.name}</span>
+            <input
+              type="number"
+              min={0}
+              className="w-24 rounded-full border border-slate-200 px-3 py-1 text-right"
+              value={values[student.id] ?? ''}
+              onChange={(event) =>
+                setValues((prev) => ({ ...prev, [student.id]: Number(event.target.value) }))
+              }
+            />
+          </label>
+        ))}
+      </div>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="rounded-full bg-gradient-to-r from-indigo-500 to-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-lg"
+        >
+          保存速度成绩
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WallboardCarousel.tsx
+++ b/src/components/WallboardCarousel.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+
+interface Slide {
+  id: string;
+  title: string;
+  description: string;
+}
+
+interface Props {
+  slides: Slide[];
+  interval?: number;
+}
+
+export function WallboardCarousel({ slides, interval = 8000 }: Props) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setIndex((prev) => (prev + 1) % slides.length);
+    }, interval);
+    return () => window.clearInterval(id);
+  }, [slides.length, interval]);
+
+  if (!slides.length) {
+    return <div className="flex h-full items-center justify-center text-xl text-white/60">暂无壁板内容</div>;
+  }
+
+  const slide = slides[index];
+  return (
+    <div className="flex h-full flex-col items-start justify-center gap-4 p-8 text-white">
+      <div className="text-sm uppercase tracking-[0.4em] text-white/60">Wallboard</div>
+      <h2 className="text-4xl font-black tracking-wide">{slide.title}</h2>
+      <p className="max-w-2xl text-2xl text-white/90">{slide.description}</p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,30 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --brand-primary: #4a6cf7;
+  --brand-secondary: #a855f7;
+  --brand-success: #10b981;
+  --brand-warning: #f59e0b;
+  --brand-danger: #ef4444;
+  --panel: #0b1220;
+  color-scheme: light;
+}
+
+html, body {
+  height: 100%;
+  font-family: 'Inter', 'Noto Sans SC', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+a {
+  @apply text-brand-primary;
+}
+
+.dark {
+  color-scheme: dark;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/assessments/index.tsx
+++ b/src/pages/assessments/index.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { testsRepo } from '../../store/repositories/testsRepo';
+import { nanoid } from '../../utils/id';
+import type { FitnessQuality, FitnessTestResult } from '../../types/models';
+
+const QUALITIES: FitnessQuality[] = ['speed', 'power', 'endurance', 'coordination', 'agility', 'balance', 'flexibility', 'core', 'accuracy'];
+
+export default function AssessmentsIndex() {
+  const [quarter, setQuarter] = useState('2025Q4');
+  const [studentId, setStudentId] = useState('demo');
+
+  const handleCreate = async () => {
+    const result: FitnessTestResult = {
+      id: nanoid(),
+      studentId,
+      quarter,
+      date: new Date().toISOString(),
+      items: QUALITIES.map((quality, idx) => ({ itemId: `${quality}-${idx}`, value: 60 + idx * 2 })),
+      radar: QUALITIES.reduce((acc, quality, idx) => ({ ...acc, [quality]: 60 + idx * 4 }), {} as Record<FitnessQuality, number>)
+    };
+    await testsRepo.upsert(result);
+    alert('季度测评已生成并同步到档案');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-bold">季度测评 & 段位考核</h2>
+        <p className="text-sm text-slate-500">录入体能数据后自动生成雷达图，满足速度阈值自动段位升级。</p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="text-sm font-medium">
+          测评季度
+          <input value={quarter} onChange={(event) => setQuarter(event.target.value)} className="mt-1 w-full rounded-xl border border-slate-200 p-3" />
+        </label>
+        <label className="text-sm font-medium">
+          学员 ID
+          <input value={studentId} onChange={(event) => setStudentId(event.target.value)} className="mt-1 w-full rounded-xl border border-slate-200 p-3" />
+        </label>
+      </div>
+      <button type="button" onClick={handleCreate} className="rounded-full bg-brand-primary px-6 py-2 text-sm font-semibold text-white">
+        生成季度测评
+      </button>
+    </div>
+  );
+}

--- a/src/pages/classes/[id].tsx
+++ b/src/pages/classes/[id].tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { classesRepo } from '../../store/repositories/classesRepo';
+import { templatesRepo } from '../../store/repositories/templatesRepo';
+import type { ClassEntity, TrainingTemplate } from '../../types/models';
+
+export default function ClassDetail() {
+  const params = useParams();
+  const [entity, setEntity] = useState<ClassEntity | undefined>();
+  const [templates, setTemplates] = useState<TrainingTemplate[]>([]);
+
+  useEffect(() => {
+    if (!params.id) return;
+    classesRepo.get(params.id).then(setEntity);
+    templatesRepo.list().then(setTemplates);
+  }, [params.id]);
+
+  if (!entity) {
+    return <div className="text-sm text-slate-500">正在加载班级信息...</div>;
+  }
+
+  const template = templates.find((t) => t.id === entity.templateId);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">{entity.name}</h2>
+          <p className="text-sm text-slate-500">教练：{entity.coachName}</p>
+        </div>
+        <Link
+          to={`/session/${entity.id}`}
+          className="rounded-full bg-gradient-to-r from-indigo-500 to-purple-600 px-5 py-2 text-sm font-semibold text-white shadow-lg"
+        >
+          开始本节课
+        </Link>
+      </div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-4">
+        <h3 className="text-sm font-semibold text-slate-600">默认课程模板</h3>
+        {template ? (
+          <div className="mt-2 space-y-2 text-sm">
+            <div className="font-medium">{template.name}</div>
+            <div className="text-xs text-slate-500">
+              {template.durationMinTotal ? `总时长 ${template.durationMinTotal} 分钟` : '未设置总时长'}
+            </div>
+            <ul className="grid gap-2 md:grid-cols-2">
+              {template.blocks.map((block) => (
+                <li key={block.id} className="rounded-xl border border-slate-100 bg-slate-50 p-3">
+                  <div className="text-sm font-semibold">{block.title}</div>
+                  <div className="text-xs text-slate-500">{block.durationMin ?? 0} min · {block.period}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="mt-2 text-sm text-slate-500">尚未绑定模板，可在模板库创建后绑定。</div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/classes/index.tsx
+++ b/src/pages/classes/index.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { nanoid } from '../../utils/id';
+import { classesRepo } from '../../store/repositories/classesRepo';
+import type { ClassEntity } from '../../types/models';
+import { Link } from 'react-router-dom';
+
+export default function ClassesIndex() {
+  const [classes, setClasses] = useState<ClassEntity[]>([]);
+
+  useEffect(() => {
+    classesRepo.list().then(setClasses);
+  }, []);
+
+  const handleCreate = async () => {
+    const entity: ClassEntity = {
+      id: nanoid(),
+      name: `体验班 ${classes.length + 1}`,
+      coachName: '勇士教练',
+      studentIds: []
+    };
+    await classesRepo.upsert(entity);
+    setClasses(await classesRepo.list());
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">班级管理</h2>
+          <p className="text-sm text-slate-500">新建班级 → 绑定学员 → 选择模板 → 开启上课</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCreate}
+          className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white"
+        >
+          新建班级
+        </button>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {classes.map((item) => (
+          <Link
+            key={item.id}
+            to={`/classes/${item.id}`}
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div className="text-lg font-semibold">{item.name}</div>
+            <div className="text-xs text-slate-500">教练：{item.coachName}</div>
+            <div className="mt-2 text-sm text-slate-600">学员数：{item.studentIds.length}</div>
+          </Link>
+        ))}
+        {!classes.length && (
+          <div className="rounded-2xl border border-dashed border-slate-300 p-6 text-slate-500">
+            暂无班级，点击右上角「新建班级」开始。
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/classes/new.tsx
+++ b/src/pages/classes/new.tsx
@@ -1,0 +1,42 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { nanoid } from '../../utils/id';
+import { classesRepo } from '../../store/repositories/classesRepo';
+
+export default function ClassNew() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('春季基础班');
+  const [coachName, setCoachName] = useState('勇士教练');
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const id = nanoid();
+    await classesRepo.upsert({ id, name, coachName, studentIds: [] });
+    navigate(`/classes/${id}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto max-w-xl space-y-4">
+      <h2 className="text-xl font-bold">新建班级</h2>
+      <label className="block text-sm font-medium">
+        班级名称
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-200 p-3"
+        />
+      </label>
+      <label className="block text-sm font-medium">
+        教练姓名
+        <input
+          value={coachName}
+          onChange={(event) => setCoachName(event.target.value)}
+          className="mt-1 w-full rounded-xl border border-slate-200 p-3"
+        />
+      </label>
+      <button type="submit" className="rounded-full bg-brand-primary px-6 py-2 text-white">
+        创建
+      </button>
+    </form>
+  );
+}

--- a/src/pages/finance/index.tsx
+++ b/src/pages/finance/index.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { billingRepo } from '../../store/repositories/billingRepo';
+import { FinanceCards } from '../../components/FinanceCards';
+import type { LessonWallet } from '../../types/models';
+import { db } from '../../store/db';
+
+const EMPTY_KPIS = { totalStudents: 0, totalRevenue: 0, consumed: 0, remaining: 0, arpu: 0, consumeRate: 0 };
+
+export default function FinanceIndex() {
+  const [kpis, setKpis] = useState(EMPTY_KPIS);
+  const [lowWallet, setLowWallet] = useState<LessonWallet[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      setKpis(await billingRepo.financeKpis());
+      const wallets: LessonWallet[] = [];
+      const studentIds = await db.students.toCollection().primaryKeys();
+      for (const id of studentIds) {
+        const wallet = await billingRepo.wallet(String(id));
+        if (wallet.remaining <= 3) {
+          wallets.push(wallet);
+        }
+      }
+      setLowWallet(wallets);
+    })();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-bold">财务看板</h2>
+        <p className="text-sm text-slate-500">总览收入、课消与续费提醒，支持 CSV 导出。</p>
+      </div>
+      <FinanceCards kpis={kpis} />
+      <section className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="text-sm font-semibold text-slate-600">续费提醒（剩余 ≤ 3 节）</h3>
+        <ul className="mt-3 space-y-2 text-sm">
+          {lowWallet.map((wallet) => (
+            <li key={wallet.studentId} className="flex items-center justify-between rounded-xl bg-slate-50 px-3 py-2">
+              <span>学员 {wallet.studentId}</span>
+              <span className="font-semibold text-brand-warning">剩余 {wallet.remaining} 节</span>
+            </li>
+          ))}
+          {!lowWallet.length && <li className="text-slate-500">暂无待续费学员。</li>}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/reports/[studentId].tsx
+++ b/src/pages/reports/[studentId].tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { studentsRepo } from '../../store/repositories/studentsRepo';
+import { generateReportDraft } from '../../utils/report';
+
+export default function ReportPreview() {
+  const params = useParams();
+  const [draft, setDraft] = useState('');
+
+  useEffect(() => {
+    if (!params.studentId) return;
+    (async () => {
+      const student = await studentsRepo.get(params.studentId!);
+      if (student) {
+        setDraft(await generateReportDraft(student.name));
+      }
+    })();
+  }, [params.studentId]);
+
+  return (
+    <div id="report-root" className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-bold">家长报告预览</h2>
+      <p className="text-sm text-slate-500">包含课时、速度曲线、花样进阶、雷达评估与教练寄语。</p>
+      <article className="rounded-2xl border border-dashed border-brand-primary/40 bg-gradient-to-br from-indigo-50 via-white to-purple-50 p-6">
+        <h3 className="text-lg font-semibold text-brand-primary">战报速递</h3>
+        <p className="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-slate-700">{draft || '正在生成报告内容...'}</p>
+      </article>
+    </div>
+  );
+}

--- a/src/pages/session/[id].tsx
+++ b/src/pages/session/[id].tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { classesRepo } from '../../store/repositories/classesRepo';
+import { studentsRepo } from '../../store/repositories/studentsRepo';
+import { sessionsRepo } from '../../store/repositories/sessionsRepo';
+import type {
+  AttendanceItem,
+  ClassEntity,
+  FreestyleChallengeRecord,
+  SessionRecord,
+  SpeedRecord,
+  Student
+} from '../../types/models';
+import { AttendanceGrid } from '../../components/AttendanceGrid';
+import { SpeedInput } from '../../components/SpeedInput';
+import { FreestylePass } from '../../components/FreestylePass';
+import { HighlightsCard } from '../../components/HighlightsCard';
+import { CommentEditor } from '../../components/CommentEditor';
+import { EnergyBar } from '../../components/EnergyBar';
+import { RankBadge } from '../../components/RankBadge';
+import { PointsTicker } from '../../components/PointsTicker';
+import { nanoid } from '../../utils/id';
+
+export default function SessionPanel() {
+  const params = useParams();
+  const [classEntity, setClassEntity] = useState<ClassEntity | undefined>();
+  const [students, setStudents] = useState<Student[]>([]);
+  const [attendance, setAttendance] = useState<AttendanceItem[]>([]);
+  const [highlights, setHighlights] = useState<string[]>([]);
+  const [pointDelta, setPointDelta] = useState<number>(0);
+  const [speeds, setSpeeds] = useState<SpeedRecord[]>([]);
+  const [freestyle, setFreestyle] = useState<FreestyleChallengeRecord[]>([]);
+
+  useEffect(() => {
+    if (!params.id) return;
+    classesRepo.get(params.id).then(setClassEntity);
+  }, [params.id]);
+
+  useEffect(() => {
+    if (!classEntity) return;
+    Promise.all(classEntity.studentIds.map((id) => studentsRepo.get(id))).then((list) =>
+      setStudents(list.filter(Boolean) as Student[])
+    );
+  }, [classEntity]);
+
+  const avgRank = useMemo(() => {
+    if (!students.length) return 0;
+    return (
+      students.reduce((sum, student) => sum + (student.currentRank ?? 1), 0) / students.length
+    ).toFixed(1);
+  }, [students]);
+
+  const handleSpeed = async (records: SpeedRecord[]) => {
+    setSpeeds(records);
+    if (records.length) {
+      setHighlights((prev) => Array.from(new Set([...prev, '30s 单摇 PR +12%'])));
+      setPointDelta((prev) => prev + 5);
+    }
+  };
+
+  const handleFreestyle = (records: FreestyleChallengeRecord[]) => {
+    setFreestyle(records);
+    if (records.length) {
+      setHighlights((prev) => Array.from(new Set([...prev, '花样挑战通关'])));
+      setPointDelta((prev) => prev + 3);
+    }
+  };
+
+  const handleComment = async () => {
+    setHighlights((prev) => Array.from(new Set([...prev, '教练评语已同步'])));
+  };
+
+  const handleFinish = async () => {
+    if (!params.id) return;
+    const session: SessionRecord = {
+      id: nanoid(),
+      classId: params.id,
+      date: new Date().toISOString(),
+      attendance,
+      speed: speeds,
+      freestyle,
+      notes: [],
+      closed: true,
+      lessonConsume: 1,
+      highlights,
+      pointEvents: []
+    };
+    await sessionsRepo.upsert(session);
+    alert('结课成功，战报草稿已生成');
+  };
+
+  return (
+    <div className="min-h-dvh bg-white dark:bg-slate-950">
+      <div className="mx-auto max-w-[1400px] space-y-4 p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <RankBadge rank={Number(avgRank) || 1} />
+            <h2 className="text-xl font-bold">
+              {classEntity?.name ?? '上课面板'} · {new Date().toLocaleDateString('zh-CN')}
+            </h2>
+          </div>
+          <div className="w-80">
+            <EnergyBar value={attendance.length * 8} />
+          </div>
+          <div className="text-xs text-slate-500">快捷键：S / F / N / E</div>
+        </div>
+        <div className="grid grid-cols-12 gap-4">
+          <aside className="col-span-12 lg:col-span-3">
+            <AttendanceGrid students={students} value={attendance} onChange={setAttendance} />
+          </aside>
+          <main className="col-span-12 space-y-4 lg:col-span-6">
+            <SpeedInput students={students} onSubmit={handleSpeed} />
+            <div className="grid gap-4 md:grid-cols-2">
+              <HighlightsCard highlights={highlights} />
+              <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <h3 className="text-sm font-semibold text-slate-600">积分事件</h3>
+                <div className="mt-3 flex items-center gap-2 text-2xl font-black text-brand-secondary">
+                  <PointsTicker delta={pointDelta} />
+                  <span className="text-sm font-medium text-slate-500">今日累计</span>
+                </div>
+              </div>
+            </div>
+          </main>
+          <aside className="col-span-12 space-y-4 lg:col-span-3">
+            <FreestylePass students={students} moves={[]} onChange={handleFreestyle} />
+            <CommentEditor onSubmit={handleComment} />
+          </aside>
+        </div>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleFinish}
+            className="rounded-2xl bg-gradient-to-r from-indigo-500 to-purple-600 px-6 py-3 text-lg font-semibold text-white shadow-lg"
+          >
+            结束课程并同步
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { templatesRepo } from '../../store/repositories/templatesRepo';
+import { parseTemplates } from '../../utils/csv';
+import { nanoid } from '../../utils/id';
+
+export default function SettingsIndex() {
+  const [json, setJson] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleImport = async () => {
+    try {
+      const templates = parseTemplates(json).map((template) => ({
+        ...template,
+        id: template.id ?? nanoid(),
+        createdAt: template.createdAt ?? new Date().toISOString()
+      }));
+      await Promise.all(templates.map((template) => templatesRepo.upsert(template)));
+      setMessage(`成功导入 ${templates.length} 个模板`);
+    } catch (error) {
+      setMessage((error as Error).message);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-bold">系统设置 & 导入导出</h2>
+        <p className="text-sm text-slate-500">支持课程模板 JSON 导入、导出备份以及品牌配置。</p>
+      </div>
+      <section className="space-y-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="text-sm font-semibold text-slate-600">导入课程模板 JSON</h3>
+        <textarea
+          value={json}
+          onChange={(event) => setJson(event.target.value)}
+          className="h-40 w-full rounded-2xl border border-slate-200 p-3 text-xs"
+          placeholder="粘贴模板数组 JSON，支持新增字段 durationMinTotal"
+        />
+        <button type="button" onClick={handleImport} className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white">
+          导入模板
+        </button>
+        {message && <div className="text-xs text-brand-success">{message}</div>}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/students/[id].tsx
+++ b/src/pages/students/[id].tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { studentsRepo } from '../../store/repositories/studentsRepo';
+import { testsRepo } from '../../store/repositories/testsRepo';
+import { billingRepo } from '../../store/repositories/billingRepo';
+import type { FitnessTestResult, LessonWallet, Student } from '../../types/models';
+import { RankBadge } from '../../components/RankBadge';
+import { EnergyBar } from '../../components/EnergyBar';
+import { ProgressChart } from '../../components/ProgressChart';
+import { RadarChart } from '../../components/RadarChart';
+import { ExportPdfButton } from '../../components/ExportPdfButton';
+import { FinanceCards } from '../../components/FinanceCards';
+
+export default function StudentProfile() {
+  const params = useParams();
+  const [student, setStudent] = useState<Student | undefined>();
+  const [tests, setTests] = useState<FitnessTestResult[]>([]);
+  const [wallet, setWallet] = useState<LessonWallet | undefined>();
+
+  useEffect(() => {
+    if (!params.id) return;
+    studentsRepo.get(params.id).then(setStudent);
+    testsRepo.listByStudent(params.id).then(setTests);
+    billingRepo.wallet(params.id).then(setWallet);
+  }, [params.id]);
+
+  const radar = tests.at(-1)?.radar ?? {
+    speed: 65,
+    power: 62,
+    endurance: 70,
+    coordination: 60,
+    agility: 68,
+    balance: 66,
+    flexibility: 64,
+    core: 63,
+    accuracy: 61
+  };
+
+  const baseline = useMemo(() => {
+    const base: Record<string, number> = {};
+    Object.keys(radar).forEach((key) => {
+      base[key] = 55;
+    });
+    return base;
+  }, [radar]);
+
+  if (!student) {
+    return <div className="text-sm text-slate-500">正在加载学员档案...</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-bold">{student.name}</h2>
+            <RankBadge rank={student.currentRank ?? 1} />
+            <div className="text-sm text-slate-500">积分：{student.pointsTotal ?? 0}</div>
+            <div className="max-w-sm text-sm text-slate-500">
+              徽章：{(student.badges ?? []).join('、') || '待解锁'}
+            </div>
+          </div>
+          <div className="w-60 space-y-2">
+            <div className="text-xs text-slate-500">课时钱包剩余</div>
+            <div className="text-3xl font-black text-brand-primary">
+              {wallet?.remaining ?? 0}
+              <span className="ml-1 text-sm font-medium text-slate-500">课时</span>
+            </div>
+            <EnergyBar value={wallet?.remaining ?? 0} max={wallet ? wallet.totalPurchased : 100} />
+          </div>
+          <ExportPdfButton target="#report-root" fileName={({ name }) => `${name ?? student.name}-成长报告.pdf`} student={student} />
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <ProgressChart
+            title="速度曲线"
+            series={[
+              { date: '2025-01-01', score: 120 },
+              { date: '2025-02-01', score: 130 },
+              { date: '2025-03-01', score: 138 }
+            ]}
+            unit="次"
+          />
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <ProgressChart
+            title="花样进阶"
+            series={[
+              { date: '2025-01-01', score: 2 },
+              { date: '2025-02-01', score: 4 },
+              { date: '2025-03-01', score: 6 }
+            ]}
+          />
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <RadarChart data={radar} baselineP50={baseline as any} />
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <FinanceCards
+            kpis={{
+              totalStudents: 1,
+              totalRevenue: 3600,
+              consumed: wallet?.totalConsumed ?? 0,
+              remaining: wallet?.remaining ?? 0,
+              arpu: 3600,
+              consumeRate: wallet && wallet.totalPurchased ? (wallet.totalConsumed / wallet.totalPurchased) * 100 : 0
+            }}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/students/index.tsx
+++ b/src/pages/students/index.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { studentsRepo } from '../../store/repositories/studentsRepo';
+import type { Student } from '../../types/models';
+import { nanoid } from '../../utils/id';
+
+export default function StudentsIndex() {
+  const [students, setStudents] = useState<Student[]>([]);
+
+  useEffect(() => {
+    studentsRepo.list().then(setStudents);
+  }, []);
+
+  const handleSeed = async () => {
+    const student: Student = {
+      id: nanoid(),
+      name: `学员${students.length + 1}`,
+      currentRank: 2,
+      pointsTotal: 36,
+      badges: ['bronze_attendance']
+    };
+    await studentsRepo.upsert(student);
+    setStudents(await studentsRepo.list());
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">学员库</h2>
+          <p className="text-sm text-slate-500">管理档案、课时钱包、测评与报告导出</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleSeed}
+            className="rounded-full border border-brand-primary px-4 py-2 text-sm text-brand-primary"
+          >
+            快速添加学员
+          </button>
+          <Link
+            to="/students/new"
+            className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white"
+          >
+            新建学员
+          </Link>
+        </div>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {students.map((student) => (
+          <Link
+            key={student.id}
+            to={`/students/${student.id}`}
+            className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div className="text-lg font-semibold">{student.name}</div>
+            <div className="text-xs text-slate-500">段位：{student.currentRank ?? 0}</div>
+            <div className="mt-2 text-sm text-slate-600">积分：{student.pointsTotal ?? 0}</div>
+          </Link>
+        ))}
+        {!students.length && (
+          <div className="rounded-2xl border border-dashed border-slate-300 p-6 text-slate-500">
+            暂无学员数据，点击「新建学员」创建档案。
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/students/new.tsx
+++ b/src/pages/students/new.tsx
@@ -1,0 +1,34 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { nanoid } from '../../utils/id';
+import { studentsRepo } from '../../store/repositories/studentsRepo';
+
+export default function StudentsNew() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const id = nanoid();
+    await studentsRepo.upsert({ id, name, guardian: { name: '家长', phone } });
+    navigate(`/students/${id}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto max-w-xl space-y-4">
+      <h2 className="text-xl font-bold">新建学员档案</h2>
+      <label className="block text-sm font-medium">
+        姓名
+        <input value={name} onChange={(event) => setName(event.target.value)} className="mt-1 w-full rounded-xl border border-slate-200 p-3" />
+      </label>
+      <label className="block text-sm font-medium">
+        家长电话
+        <input value={phone} onChange={(event) => setPhone(event.target.value)} className="mt-1 w-full rounded-xl border border-slate-200 p-3" />
+      </label>
+      <button type="submit" className="rounded-full bg-brand-primary px-6 py-2 text-white">
+        创建档案
+      </button>
+    </form>
+  );
+}

--- a/src/pages/templates/index.tsx
+++ b/src/pages/templates/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { templatesRepo } from '../../store/repositories/templatesRepo';
+import type { TrainingTemplate } from '../../types/models';
+
+export default function TemplatesIndex() {
+  const [templates, setTemplates] = useState<TrainingTemplate[]>([]);
+
+  useEffect(() => {
+    templatesRepo.list().then(setTemplates);
+  }, []);
+
+  const avgDuration = useMemo(() => {
+    if (!templates.length) return 0;
+    return (
+      templates.reduce((sum, template) => sum + (template.durationMinTotal ?? 0), 0) /
+      templates.length
+    );
+  }, [templates]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-bold">课程模板库</h2>
+          <p className="text-sm text-slate-500">平均总时长：{avgDuration.toFixed(1)} 分钟</p>
+        </div>
+        <Link to="/templates/new" className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white">
+          新建模板
+        </Link>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        {templates.map((template) => (
+          <article
+            key={template.id}
+            className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">{template.name}</h3>
+                <p className="text-xs text-slate-500">阶段：{template.period}</p>
+              </div>
+              <div className="rounded-full bg-brand-primary/10 px-3 py-1 text-xs font-semibold text-brand-primary">
+                {template.durationMinTotal ?? 0} min
+              </div>
+            </div>
+            <ul className="mt-4 space-y-2 text-sm">
+              {template.blocks.map((block) => (
+                <li key={block.id} className="rounded-xl bg-slate-50 px-3 py-2">
+                  <div className="font-medium">{block.title}</div>
+                  <div className="text-xs text-slate-500">
+                    {block.durationMin ?? 0} 分钟 · {block.period}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+        {!templates.length && (
+          <div className="rounded-3xl border border-dashed border-slate-300 p-6 text-slate-500">
+            暂无模板，可点击右上角创建或导入 JSON。
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/templates/new.tsx
+++ b/src/pages/templates/new.tsx
@@ -1,0 +1,122 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { nanoid } from '../../utils/id';
+import { templatesRepo } from '../../store/repositories/templatesRepo';
+import type { Period, TemplateBlock, TrainingTemplate } from '../../types/models';
+
+const BLOCK_PRESETS: Array<{ title: string; period: Period; duration: number }> = [
+  { title: '热身激活', period: 'PREP', duration: 10 },
+  { title: '专项技能', period: 'SPEC', duration: 20 },
+  { title: '体能素质', period: 'SPEC', duration: 15 },
+  { title: '花样进阶', period: 'SPEC', duration: 15 },
+  { title: '游戏挑战', period: 'COMP', duration: 10 },
+  { title: '放松反馈', period: 'PREP', duration: 5 }
+];
+
+export default function TemplateNew() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('基础准备课 A');
+  const [period, setPeriod] = useState<Period>('PREP');
+  const [durationMinTotal, setDurationMinTotal] = useState(75);
+  const [blocks, setBlocks] = useState<TemplateBlock[]>(
+    BLOCK_PRESETS.map((preset) => ({
+      id: nanoid(),
+      title: preset.title,
+      period: preset.period,
+      durationMin: preset.duration,
+      notes: `${preset.title} - 默认安排`
+    }))
+  );
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const template: TrainingTemplate = {
+      id: nanoid(),
+      name,
+      period,
+      durationMinTotal,
+      blocks,
+      createdAt: new Date().toISOString()
+    };
+    await templatesRepo.upsert(template);
+    navigate('/templates');
+  };
+
+  const totalMinutes = blocks.reduce((sum, block) => sum + (block.durationMin ?? 0), 0);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold">新建课程模板</h2>
+        <div className="text-sm text-slate-500">
+          已排课时长 {totalMinutes} / 目标 {durationMinTotal} 分钟
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="text-sm font-medium">
+          模板名称
+          <input value={name} onChange={(event) => setName(event.target.value)} className="mt-1 w-full rounded-xl border border-slate-200 p-3" />
+        </label>
+        <label className="text-sm font-medium">
+          适用阶段
+          <select value={period} onChange={(event) => setPeriod(event.target.value as Period)} className="mt-1 w-full rounded-xl border border-slate-200 p-3">
+            <option value="PREP">PREP · 基础</option>
+            <option value="SPEC">SPEC · 提升</option>
+            <option value="COMP">COMP · 竞赛</option>
+          </select>
+        </label>
+        <label className="text-sm font-medium">
+          总时长 (60–90)
+          <input
+            type="number"
+            min={60}
+            max={90}
+            value={durationMinTotal}
+            onChange={(event) => setDurationMinTotal(Number(event.target.value))}
+            className="mt-1 w-full rounded-xl border border-slate-200 p-3"
+          />
+        </label>
+      </div>
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-slate-600">区块设计</h3>
+        {blocks.map((block, idx) => (
+          <div key={block.id} className="rounded-2xl border border-slate-200 bg-white p-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-primary/10 text-sm font-semibold text-brand-primary">
+                {idx + 1}
+              </span>
+              <input
+                value={block.title}
+                onChange={(event) =>
+                  setBlocks((prev) => prev.map((item) => (item.id === block.id ? { ...item, title: event.target.value } : item)))
+                }
+                className="flex-1 rounded-xl border border-slate-200 p-2 text-sm"
+              />
+              <input
+                type="number"
+                min={5}
+                max={40}
+                value={block.durationMin ?? 0}
+                onChange={(event) =>
+                  setBlocks((prev) => prev.map((item) => (item.id === block.id ? { ...item, durationMin: Number(event.target.value) } : item)))
+                }
+                className="w-24 rounded-xl border border-slate-200 p-2 text-sm"
+              />
+            </div>
+            <textarea
+              value={block.notes ?? ''}
+              onChange={(event) =>
+                setBlocks((prev) => prev.map((item) => (item.id === block.id ? { ...item, notes: event.target.value } : item)))
+              }
+              className="mt-3 w-full rounded-xl border border-slate-200 p-3 text-sm"
+              placeholder="备注：目标素质、花样建议、积分策略等"
+            />
+          </div>
+        ))}
+      </section>
+      <button type="submit" className="rounded-full bg-gradient-to-r from-indigo-500 to-purple-600 px-6 py-3 text-white shadow-lg">
+        保存模板
+      </button>
+    </form>
+  );
+}

--- a/src/pages/wallboard.tsx
+++ b/src/pages/wallboard.tsx
@@ -1,0 +1,61 @@
+import { EnergyBar } from '../components/EnergyBar';
+import { WallboardCarousel } from '../components/WallboardCarousel';
+import { RankBadge } from '../components/RankBadge';
+import { Leaderboard } from '../components/Leaderboard';
+import { SpeedBoard } from '../components/SpeedBoard';
+import { HighlightsMarquee } from '../components/HighlightsMarquee';
+
+export default function Wallboard() {
+  const slides = [
+    { id: 'mission', title: '今日任务 · 激活-学习-巩固-挑战-恢复', description: '热身激活 → 专项技能 → 花样进阶 → 游戏挑战 → 放松反馈' },
+    { id: 'points', title: '积分榜', description: 'Top 8 勇士积分实时更新，保持冲刺！' },
+    { id: 'speed', title: '速度榜', description: '30 秒单摇榜单，PR 自动点亮星标。' },
+    { id: 'highlights', title: '本节高光', description: 'PR 与通关即时上墙，大家一起为队友喝彩。' }
+  ];
+
+  return (
+    <div className="min-h-dvh bg-[#0B1220] p-6 text-white">
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-black tracking-wide">春季基础班 · 今日战斗</h1>
+          <p className="text-sm text-white/60">壁板模式 · 自动轮播 · 快捷键 B/F</p>
+        </div>
+        <div className="w-80">
+          <EnergyBar value={72} />
+        </div>
+      </header>
+      <section className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <div className="aspect-[16/9] overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-2xl">
+            <WallboardCarousel slides={slides} />
+          </div>
+          <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6">
+            <HighlightsMarquee highlights={["30s 单摇 PR +12%", "花样通过：交叉双摇", "团队积分 +15"]} />
+          </div>
+        </div>
+        <div className="space-y-4">
+          <Leaderboard
+            items={[
+              { id: '1', name: '林小勇', points: 126 },
+              { id: '2', name: '周小捷', points: 118 },
+              { id: '3', name: '王小燃', points: 112 }
+            ]}
+          />
+          <SpeedBoard
+            windowLabel="30s 单摇"
+            items={[
+              { id: '1', name: '林小勇', reps: 138, isPr: true },
+              { id: '2', name: '周小捷', reps: 130 },
+              { id: '3', name: '王小燃', reps: 128 }
+            ]}
+          />
+        </div>
+      </section>
+      <footer className="mt-6 grid grid-cols-9 gap-2">
+        {Array.from({ length: 9 }).map((_, index) => (
+          <RankBadge key={index} rank={index + 1} />
+        ))}
+      </footer>
+    </div>
+  );
+}

--- a/src/seeds/benchmarks.json
+++ b/src/seeds/benchmarks.json
@@ -1,0 +1,4 @@
+[
+  { "id": "speed-6-8", "quality": "speed", "ageMin": 6, "ageMax": 8, "gender": "all", "unit": "count", "p25": 80, "p50": 100, "p75": 120 },
+  { "id": "endurance-6-8", "quality": "endurance", "ageMin": 6, "ageMax": 8, "gender": "all", "unit": "count", "p25": 40, "p50": 55, "p75": 70 }
+]

--- a/src/seeds/public_library.json
+++ b/src/seeds/public_library.json
@@ -1,0 +1,10 @@
+{
+  "speed_rank_thresholds": [60, 70, 80, 100, 110, 120, 150, 160, 170],
+  "rank_moves": [
+    { "id": "move-l1-1", "rank": 1, "name": "基础单摇" },
+    { "id": "move-l2-1", "rank": 2, "name": "交叉跳" }
+  ],
+  "warrior_path": [
+    { "id": "path-1", "rank": 1, "title": "节奏新兵营", "moveIds": ["move-l1-1"], "points": 50 }
+  ]
+}

--- a/src/seeds/seed.json
+++ b/src/seeds/seed.json
@@ -1,0 +1,38 @@
+{
+  "students": [
+    {
+      "id": "stu-001",
+      "name": "林小勇",
+      "currentRank": 3,
+      "pointsTotal": 128,
+      "badges": ["bronze_attendance", "silver_pr_star"],
+      "joinDate": "2024-09-01"
+    }
+  ],
+  "classes": [
+    {
+      "id": "class-001",
+      "name": "春季基础班",
+      "coachName": "Alex",
+      "templateId": "tpl-base-a",
+      "studentIds": ["stu-001"]
+    }
+  ],
+  "templates": [
+    {
+      "id": "tpl-base-a",
+      "name": "基础准备课 A",
+      "period": "PREP",
+      "durationMinTotal": 75,
+      "blocks": [
+        { "id": "b1", "title": "热身激活", "period": "PREP", "durationMin": 10 },
+        { "id": "b2", "title": "基础单摇", "period": "PREP", "durationMin": 15 },
+        { "id": "b3", "title": "步法协调", "period": "SPEC", "durationMin": 10 },
+        { "id": "b4", "title": "花样体验", "period": "SPEC", "durationMin": 15 },
+        { "id": "b5", "title": "体能循环", "period": "SPEC", "durationMin": 15 },
+        { "id": "b6", "title": "放松反馈", "period": "PREP", "durationMin": 10 }
+      ],
+      "createdAt": "2024-12-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -1,0 +1,38 @@
+import Dexie, { Table } from 'dexie';
+import type {
+  Student,
+  ClassEntity,
+  TrainingTemplate,
+  SessionRecord,
+  FitnessTestResult,
+  RankExamRecord,
+  LessonPackage,
+  PaymentRecord
+} from '../types/models';
+
+export class AppDB extends Dexie {
+  students!: Table<Student, string>;
+  classes!: Table<ClassEntity, string>;
+  templates!: Table<TrainingTemplate, string>;
+  sessions!: Table<SessionRecord, string>;
+  tests!: Table<FitnessTestResult, string>;
+  rankExams!: Table<RankExamRecord, string>;
+  lessonPackages!: Table<LessonPackage, string>;
+  payments!: Table<PaymentRecord, string>;
+
+  constructor() {
+    super('jumpRopeDB');
+    this.version(1).stores({
+      students: 'id, name, currentRank',
+      classes: 'id, name',
+      templates: 'id, name, period',
+      sessions: 'id, classId, date, closed',
+      tests: 'id, studentId, quarter, date',
+      rankExams: 'id, studentId, date',
+      lessonPackages: 'id, studentId, purchasedAt',
+      payments: 'id, studentId, paidAt'
+    });
+  }
+}
+
+export const db = new AppDB();

--- a/src/store/repositories/billingRepo.ts
+++ b/src/store/repositories/billingRepo.ts
@@ -1,0 +1,44 @@
+import { db } from '../db';
+import type { LessonPackage, LessonWallet, PaymentRecord } from '../../types/models';
+import { calcWallet } from './wallet';
+
+export const billingRepo = {
+  async addPackage(pkg: LessonPackage, payment: PaymentRecord) {
+    await db.transaction('rw', db.lessonPackages, db.payments, async () => {
+      await db.lessonPackages.put(pkg);
+      await db.payments.put(payment);
+    });
+  },
+  async paymentsByStudent(studentId: string) {
+    return db.payments.where('studentId').equals(studentId).sortBy('paidAt');
+  },
+  async packagesByStudent(studentId: string) {
+    return db.lessonPackages.where('studentId').equals(studentId).sortBy('purchasedAt');
+  },
+  async wallet(studentId: string): Promise<LessonWallet> {
+    return calcWallet(studentId);
+  },
+  async financeKpis() {
+    const [students, payments, walletMap] = await Promise.all([
+      db.students.toArray(),
+      db.payments.toArray(),
+      (async () => {
+        const map = new Map<string, LessonWallet>();
+        for (const student of await db.students.toArray()) {
+          map.set(student.id, await calcWallet(student.id));
+        }
+        return map;
+      })()
+    ]);
+
+    const totalStudents = students.length;
+    const totalRevenue = payments.reduce((sum, p) => sum + p.amount, 0);
+    const consumed = Array.from(walletMap.values()).reduce((sum, w) => sum + w.totalConsumed, 0);
+    const remaining = Array.from(walletMap.values()).reduce((sum, w) => sum + w.remaining, 0);
+    const totalPurchased = consumed + remaining;
+    const arpu = totalStudents ? totalRevenue / totalStudents : 0;
+    const consumeRate = totalPurchased ? (consumed / totalPurchased) * 100 : 0;
+
+    return { totalStudents, totalRevenue, consumed, remaining, arpu, consumeRate };
+  }
+};

--- a/src/store/repositories/classesRepo.ts
+++ b/src/store/repositories/classesRepo.ts
@@ -1,0 +1,25 @@
+import { db } from '../db';
+import type { ClassEntity, TrainingTemplate } from '../../types/models';
+
+export const classesRepo = {
+  async upsert(entity: ClassEntity) {
+    await db.classes.put(entity);
+    return entity;
+  },
+  async list() {
+    return db.classes.toArray();
+  },
+  async get(id: string) {
+    return db.classes.get(id);
+  },
+  async remove(id: string) {
+    return db.classes.delete(id);
+  },
+  async setTemplate(classId: string, template: TrainingTemplate | undefined) {
+    if (!template) {
+      await db.classes.update(classId, { templateId: undefined });
+      return;
+    }
+    await db.classes.update(classId, { templateId: template.id });
+  }
+};

--- a/src/store/repositories/sessionsRepo.ts
+++ b/src/store/repositories/sessionsRepo.ts
@@ -1,0 +1,18 @@
+import { db } from '../db';
+import type { SessionRecord } from '../../types/models';
+
+export const sessionsRepo = {
+  async upsert(session: SessionRecord) {
+    await db.sessions.put(session);
+    return session;
+  },
+  async listByClass(classId: string) {
+    return db.sessions.where('classId').equals(classId).reverse().sortBy('date');
+  },
+  async get(id: string) {
+    return db.sessions.get(id);
+  },
+  async remove(id: string) {
+    return db.sessions.delete(id);
+  }
+};

--- a/src/store/repositories/studentsRepo.ts
+++ b/src/store/repositories/studentsRepo.ts
@@ -1,0 +1,22 @@
+import { db } from '../db';
+import type { LessonWallet, Student } from '../../types/models';
+import { calcWallet } from './wallet';
+
+export const studentsRepo = {
+  async upsert(student: Student) {
+    await db.students.put(student);
+    return student;
+  },
+  async list() {
+    return db.students.toArray();
+  },
+  async get(id: string) {
+    return db.students.get(id);
+  },
+  async remove(id: string) {
+    return db.students.delete(id);
+  },
+  async wallet(studentId: string): Promise<LessonWallet> {
+    return calcWallet(studentId);
+  }
+};

--- a/src/store/repositories/templatesRepo.ts
+++ b/src/store/repositories/templatesRepo.ts
@@ -1,0 +1,18 @@
+import { db } from '../db';
+import type { TrainingTemplate } from '../../types/models';
+
+export const templatesRepo = {
+  async upsert(template: TrainingTemplate) {
+    await db.templates.put(template);
+    return template;
+  },
+  async list() {
+    return db.templates.toArray();
+  },
+  async get(id: string) {
+    return db.templates.get(id);
+  },
+  async remove(id: string) {
+    return db.templates.delete(id);
+  }
+};

--- a/src/store/repositories/testsRepo.ts
+++ b/src/store/repositories/testsRepo.ts
@@ -1,0 +1,18 @@
+import { db } from '../db';
+import type { FitnessTestResult } from '../../types/models';
+
+export const testsRepo = {
+  async upsert(result: FitnessTestResult) {
+    await db.tests.put(result);
+    return result;
+  },
+  async listByStudent(studentId: string) {
+    return db.tests.where('studentId').equals(studentId).sortBy('date');
+  },
+  async get(id: string) {
+    return db.tests.get(id);
+  },
+  async remove(id: string) {
+    return db.tests.delete(id);
+  }
+};

--- a/src/store/repositories/wallet.ts
+++ b/src/store/repositories/wallet.ts
@@ -1,0 +1,25 @@
+import { db } from '../db';
+import type { LessonWallet } from '../../types/models';
+
+export async function calcWallet(studentId: string): Promise<LessonWallet> {
+  const packages = await db.lessonPackages.where('studentId').equals(studentId).toArray();
+  const sessions = await db.sessions.toArray();
+  const consumed = sessions.reduce((acc, session) => {
+    const overrides = session.consumeOverrides?.find((c) => c.studentId === studentId);
+    if (overrides) {
+      return acc + overrides.consume;
+    }
+    const attended = session.attendance?.find((a) => a.studentId === studentId)?.present;
+    if (attended) {
+      return acc + (session.lessonConsume ?? 1);
+    }
+    return acc;
+  }, 0);
+  const totalPurchased = packages.reduce((acc, pkg) => acc + pkg.purchasedLessons, 0);
+  return {
+    studentId,
+    totalPurchased,
+    totalConsumed: consumed,
+    remaining: totalPurchased - consumed
+  };
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,0 +1,215 @@
+export type ID = string;
+export type ISODate = string;
+export type Period = 'PREP' | 'SPEC' | 'COMP';
+export type WindowSec = 10 | 20 | 30 | 60;
+export type JumpMode = 'single' | 'double';
+export type FitnessQuality =
+  | 'speed'
+  | 'power'
+  | 'endurance'
+  | 'coordination'
+  | 'agility'
+  | 'balance'
+  | 'flexibility'
+  | 'core'
+  | 'accuracy';
+
+export interface RankMove {
+  id: ID;
+  rank: number;
+  name: string;
+  tags?: string[];
+  description?: string;
+  criteria?: string;
+}
+
+export interface WarriorPathNode {
+  id: ID;
+  rank: number;
+  title: string;
+  moveIds: ID[];
+  points: number;
+}
+
+export interface GameDrill {
+  id: ID;
+  name: string;
+  qualityTags: FitnessQuality[];
+  description?: string;
+}
+
+export interface TemplateBlock {
+  id: ID;
+  title: string;
+  period: Period;
+  durationMin?: number;
+  rankMoveIds?: ID[];
+  qualities?: FitnessQuality[];
+  gameIds?: ID[];
+  notes?: string;
+}
+
+export interface TrainingTemplate {
+  id: ID;
+  name: string;
+  period: Period;
+  weeks?: number;
+  durationMinTotal?: number;
+  blocks: TemplateBlock[];
+  createdAt: ISODate;
+}
+
+export interface Student {
+  id: ID;
+  name: string;
+  gender?: 'M' | 'F';
+  birth?: ISODate;
+  guardian?: { name: string; phone?: string };
+  joinDate?: ISODate;
+  currentRank?: number;
+  tags?: string[];
+  pointsTotal?: number;
+  badges?: string[];
+}
+
+export interface ClassEntity {
+  id: ID;
+  name: string;
+  coachName: string;
+  schedule?: string;
+  templateId?: ID;
+  studentIds: ID[];
+}
+
+export interface AttendanceItem {
+  studentId: ID;
+  present: boolean;
+  remark?: string;
+}
+
+export interface SpeedRecord {
+  id: ID;
+  studentId: ID;
+  mode: JumpMode;
+  window: WindowSec;
+  reps: number;
+  date?: ISODate;
+}
+
+export interface FreestyleChallengeRecord {
+  id: ID;
+  studentId: ID;
+  moveId: ID;
+  passed: boolean;
+  note?: string;
+  date?: ISODate;
+}
+
+export interface TrainingNote {
+  id: ID;
+  studentId: ID;
+  rating?: number;
+  comments?: string;
+  tags?: string[];
+}
+
+export interface SessionRecord {
+  id: ID;
+  classId: ID;
+  date: ISODate;
+  templateId?: ID;
+  attendance: AttendanceItem[];
+  speed: SpeedRecord[];
+  freestyle: FreestyleChallengeRecord[];
+  notes: TrainingNote[];
+  closed: boolean;
+  lessonConsume?: number;
+  consumeOverrides?: Array<{ studentId: ID; consume: number }>;
+  highlights?: string[];
+  pointEvents?: PointEvent[];
+}
+
+export type PointEventType = 'attendance' | 'pr' | 'freestyle_pass' | 'coach_bonus';
+
+export interface PointEvent {
+  id: ID;
+  sessionId: ID;
+  studentId: ID;
+  type: PointEventType;
+  points: number;
+  reason?: string;
+  createdAt: ISODate;
+}
+
+export interface FitnessTestItem {
+  id: ID;
+  name: string;
+  quality: FitnessQuality;
+  unit: 'count' | 'cm' | 's' | 'grade';
+}
+
+export interface FitnessTestResult {
+  id: ID;
+  studentId: ID;
+  quarter: string;
+  date: ISODate;
+  items: Array<{ itemId: ID; value: number }>;
+  radar: Record<FitnessQuality, number>;
+}
+
+export interface RankExamRecord {
+  id: ID;
+  studentId: ID;
+  date: ISODate;
+  fromRank: number;
+  toRank: number;
+  passed: boolean;
+  notes?: string;
+}
+
+export interface LessonPackage {
+  id: ID;
+  studentId: ID;
+  purchasedLessons: number;
+  price: number;
+  unitPrice?: number;
+  purchasedAt: ISODate;
+  remark?: string;
+}
+
+export interface PaymentRecord {
+  id: ID;
+  studentId: ID;
+  packageId: ID;
+  amount: number;
+  method?: 'cash' | 'wechat' | 'alipay' | 'card' | 'other';
+  paidAt: ISODate;
+}
+
+export interface LessonWallet {
+  studentId: ID;
+  totalPurchased: number;
+  totalConsumed: number;
+  remaining: number;
+}
+
+export interface Benchmark {
+  id: ID;
+  quality: FitnessQuality;
+  ageMin: number;
+  ageMax: number;
+  gender?: 'M' | 'F' | 'all';
+  unit: 'count' | 'cm' | 's' | 'grade';
+  p25: number;
+  p50: number;
+  p75: number;
+}
+
+export interface Recommendation {
+  id: ID;
+  studentId: ID;
+  createdAt: ISODate;
+  reason: string;
+  templateId: ID;
+  applied: boolean;
+}

--- a/src/utils/calc.ts
+++ b/src/utils/calc.ts
@@ -1,0 +1,51 @@
+import type { FitnessQuality, Student } from '../types/models';
+
+export const SPEED_THRESHOLDS = [60, 70, 80, 100, 110, 120, 150, 160, 170];
+
+export function evalSpeedRank(best30Single: number) {
+  let rank = 0;
+  for (let i = 0; i < SPEED_THRESHOLDS.length; i += 1) {
+    if (best30Single >= SPEED_THRESHOLDS[i]) {
+      rank = i + 1;
+    }
+  }
+  return rank;
+}
+
+export function maybeUpgradeRank(student: Student, best30Single: number) {
+  const next = evalSpeedRank(best30Single);
+  if (next > (student.currentRank ?? 0)) {
+    student.currentRank = next;
+  }
+  return student;
+}
+
+export interface BenchmarkEntry {
+  quality: FitnessQuality;
+  age: number;
+  gender?: 'M' | 'F';
+  p25: number;
+  p50: number;
+  p75: number;
+}
+
+export function normalizeByBenchmark(
+  value: number,
+  benchmark?: BenchmarkEntry
+): { score: number; ref?: BenchmarkEntry } {
+  if (!benchmark) {
+    return { score: 0 };
+  }
+  const { p25, p50, p75 } = benchmark;
+  let score = 0;
+  if (value <= p25) {
+    score = 60 * (value / Math.max(1, p25));
+  } else if (value <= p50) {
+    score = 60 + 15 * ((value - p25) / Math.max(1, p50 - p25));
+  } else if (value <= p75) {
+    score = 75 + 15 * ((value - p50) / Math.max(1, p75 - p50));
+  } else {
+    score = 90 + 10 * ((value - p75) / Math.max(1, p75));
+  }
+  return { score: Math.max(0, Math.min(100, score)), ref: benchmark };
+}

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,15 @@
+import type { Student, TrainingTemplate } from '../types/models';
+
+export function exportStudents(students: Student[]): string {
+  const header = ['name', 'gender', 'guardian', 'phone'];
+  const rows = students.map((student) => [student.name, student.gender ?? '', student.guardian?.name ?? '', student.guardian?.phone ?? '']);
+  return [header, ...rows].map((row) => row.map((cell) => `"${cell}"`).join(',')).join('\n');
+}
+
+export function parseTemplates(json: string): TrainingTemplate[] {
+  const data = JSON.parse(json);
+  if (!Array.isArray(data)) {
+    throw new Error('模板导入需要数组格式');
+  }
+  return data as TrainingTemplate[];
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,16 @@
+export function nanoid(size = 16): string {
+  const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  let id = '';
+  const cryptoObj = typeof crypto !== 'undefined' ? crypto : undefined;
+  if (cryptoObj?.getRandomValues) {
+    const values = cryptoObj.getRandomValues(new Uint32Array(size));
+    for (let i = 0; i < size; i += 1) {
+      id += chars[values[i] % chars.length];
+    }
+    return id;
+  }
+  for (let i = 0; i < size; i += 1) {
+    id += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return id;
+}

--- a/src/utils/recommend.ts
+++ b/src/utils/recommend.ts
@@ -1,0 +1,20 @@
+import type { Recommendation, TrainingTemplate } from '../types/models';
+import { nanoid } from './id';
+
+export function recommendTemplateByWeakness(
+  weakness: string,
+  templates: TrainingTemplate[]
+): Recommendation | undefined {
+  const candidate = templates.find((template) =>
+    template.blocks.some((block) => block.notes?.includes(weakness) || block.title.includes(weakness))
+  );
+  if (!candidate) return undefined;
+  return {
+    id: nanoid(),
+    studentId: 'temp',
+    createdAt: new Date().toISOString(),
+    reason: `针对 ${weakness} 的提升建议`,
+    templateId: candidate.id,
+    applied: false
+  };
+}

--- a/src/utils/report.ts
+++ b/src/utils/report.ts
@@ -1,0 +1,3 @@
+export async function generateReportDraft(studentName: string) {
+  return `【战报】${studentName} 在本节课表现突出，PR 再创新高！`;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['index.html', './src/**/*.{ts,tsx}'],
+  darkMode: ['class'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: 'var(--brand-primary)',
+          secondary: 'var(--brand-secondary)',
+          success: 'var(--brand-success)',
+          warning: 'var(--brand-warning)',
+          danger: 'var(--brand-danger)'
+        },
+        panel: 'var(--panel)'
+      },
+      animation: {
+        glow: 'glow 3s ease-in-out infinite'
+      },
+      keyframes: {
+        glow: {
+          '0%, 100%': { boxShadow: '0 0 40px rgba(74,108,247,0.25)' },
+          '50%': { boxShadow: '0 0 60px rgba(148,93,255,0.45)' }
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind frontend with Dexie data layer and routing that matches the jump rope teaching workflow
- implement core UI building blocks including energy, rank, leaderboard, finance, and classroom panels with the new 60–90 minute template logic
- provide repository helpers, utility stubs, and seed data to support offline IndexedDB storage, template import/export, and finance calculations

## Testing
- npm install *(fails: registry access forbidden in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e62cda2f04832cad80a8c3deb0d902